### PR TITLE
Add React-based frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ uvicorn app.main:app --reload
 - `GET /healthcheck` – check application status.
 - `POST /transcribe` – upload an audio file (`multipart/form-data`) and receive a transcript.
 - `POST /synthesize` – submit text and receive synthesized speech in WAV format.
+
+## Frontend Usage
+
+A simple React-based interface is provided in `frontend/index.html`. Start the
+backend server and open this file in your browser. The page allows you to upload
+an audio file for transcription or enter text to generate speech without any
+build step because React is loaded from a CDN.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Saba - Amharic Speech App</title>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    .section { margin-bottom: 2em; }
+    textarea { width: 100%; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    function App() {
+      const [transcript, setTranscript] = React.useState('');
+      const [audioUrl, setAudioUrl] = React.useState(null);
+      const audioRef = React.useRef(null);
+
+      async function transcribe() {
+        const input = document.getElementById('audioInput');
+        if (!input.files.length) {
+          alert('Please select an audio file');
+          return;
+        }
+        const formData = new FormData();
+        formData.append('file', input.files[0]);
+        const res = await fetch('/transcribe', { method: 'POST', body: formData });
+        if (res.ok) {
+          const data = await res.json();
+          setTranscript(data.transcript);
+        } else {
+          alert('Transcription failed');
+        }
+      }
+
+      async function synthesize() {
+        const text = document.getElementById('ttsText').value;
+        if (!text) { alert('Please enter text'); return; }
+        const formData = new FormData();
+        formData.append('text', text);
+        const res = await fetch('/synthesize', { method: 'POST', body: formData });
+        if (res.ok) {
+          const blob = await res.blob();
+          const url = URL.createObjectURL(blob);
+          setAudioUrl(url);
+          setTimeout(() => { audioRef.current && audioRef.current.play(); }, 100);
+        } else {
+          alert('Synthesis failed');
+        }
+      }
+
+      return (
+        <div>
+          <h1>Saba</h1>
+          <div className="section">
+            <h2>Speech to Text</h2>
+            <input type="file" id="audioInput" accept="audio/*" />
+            <button onClick={transcribe}>Transcribe</button>
+            <pre>{transcript}</pre>
+          </div>
+          <div className="section">
+            <h2>Text to Speech</h2>
+            <textarea id="ttsText" rows="4" placeholder="Enter text..."></textarea><br/>
+            <button onClick={synthesize}>Synthesize</button>
+            {audioUrl && <audio id="ttsAudio" ref={audioRef} controls src={audioUrl}></audio>}
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.render(<App />, document.getElementById('root'));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the plain HTML interface with a CDN-loaded React implementation
- update README instructions for the React interface

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68510c3b8760832094b4c821425474a9