### PR TITLE
Add ASR training script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,22 @@ A simple React-based interface is provided in `frontend/index.html`. Start the
 backend server and open this file in your browser. The page allows you to upload
 an audio file for transcription or enter text to generate speech without any
 build step because React is loaded from a CDN.
+
+## Training
+
+You can fine-tune the ASR model on your own dataset using the provided
+`app/train_asr.py` script. The dataset must contain `audio` and `text` columns.
+
+Install the optional training dependencies and run:
+
+```bash
+python -m app.train_asr --dataset /path/to/dataset --output ./asr_model
+```
+
+After training, load the saved model by passing the output directory to
+`ASRModel`:
+
+```python
+from app.models.asr import ASRModel
+asr = ASRModel(model="./asr_model")
+```

--- a/app/models/asr.py
+++ b/app/models/asr.py
@@ -3,8 +3,15 @@ from tempfile import NamedTemporaryFile
 from transformers import pipeline
 
 class ASRModel:
-    def __init__(self, model_name: str = "openai/whisper-base"):
-        self.pipe = pipeline("automatic-speech-recognition", model=model_name)
+    def __init__(self, model: str = "openai/whisper-base"):
+        """Initialize the speech recognition pipeline.
+
+        Parameters
+        ----------
+        model:
+            HuggingFace model name or path to a local checkpoint.
+        """
+        self.pipe = pipeline("automatic-speech-recognition", model=model)
 
     async def transcribe(self, file):
         with NamedTemporaryFile(delete=False, suffix=file.filename) as tmp:

--- a/app/train_asr.py
+++ b/app/train_asr.py
@@ -1,0 +1,68 @@
+import argparse
+
+from datasets import load_dataset, Audio
+from transformers import (
+    WhisperForConditionalGeneration,
+    WhisperProcessor,
+    TrainingArguments,
+    Trainer,
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Fine-tune a Whisper ASR model")
+    parser.add_argument("--dataset", required=True, help="Path or dataset identifier")
+    parser.add_argument("--output", required=True, help="Directory to save the fine-tuned model")
+    parser.add_argument(
+        "--model-name",
+        default="openai/whisper-base",
+        help="Model name or path to the base checkpoint",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    ds = load_dataset(args.dataset)
+    ds = ds.cast_column("audio", Audio(sampling_rate=16000))
+
+    processor = WhisperProcessor.from_pretrained(args.model_name)
+    model = WhisperForConditionalGeneration.from_pretrained(args.model_name)
+
+    def preprocess(batch):
+        audio = batch["audio"]
+        inputs = processor(
+            audio["array"], sampling_rate=audio["sampling_rate"], return_tensors="pt"
+        )
+        batch["input_features"] = inputs.input_features[0]
+        with processor.as_target_processor():
+            batch["labels"] = processor(batch["text"]).input_ids
+        return batch
+
+    ds = ds.map(preprocess)
+
+    training_args = TrainingArguments(
+        output_dir=args.output,
+        per_device_train_batch_size=8,
+        per_device_eval_batch_size=8,
+        num_train_epochs=1,
+        evaluation_strategy="epoch",
+        save_strategy="epoch",
+        logging_steps=10,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=ds.get("train"),
+        eval_dataset=ds.get("validation"),
+    )
+
+    trainer.train()
+    trainer.save_model(args.output)
+    processor.save_pretrained(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 transformers
+datasets
 torchaudio
 pydub
 soundfile


### PR DESCRIPTION
## Summary
- create `app/train_asr.py` for fine-tuning Whisper models
- allow `ASRModel` to load models via path or hub id
- document training usage in README
- include `datasets` in dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68516c8b9d808320b0671267ce92f5c9